### PR TITLE
UI resize improvement based on 1.8.9390

### DIFF
--- a/TAS.Client/EventPanelResizer.cs
+++ b/TAS.Client/EventPanelResizer.cs
@@ -1,0 +1,28 @@
+﻿
+namespace TAS.Client.Views
+{
+    class EventPanelResizer
+    {
+        public EventPanelResizer(System.Windows.Controls.Grid grid, System.Windows.Controls.TextBlock offsetLabel)
+        {
+            _grid = grid;
+            _offsetLabel = offsetLabel;
+            _offsetLabel.IsVisibleChanged += (s, e) => Resize();
+            _baseSize = grid.RowDefinitions[0].Height.Value;
+            Resize();
+        }
+        readonly System.Windows.Controls.Grid _grid;
+        readonly System.Windows.Controls.TextBlock _offsetLabel;
+        readonly double _baseSize;
+        void Resize()
+        {
+            double newHeight = _baseSize;
+            if (_offsetLabel.IsVisible)
+            {
+                _offsetLabel.Measure(new System.Windows.Size(double.PositiveInfinity, double.PositiveInfinity));
+                newHeight = _baseSize + _offsetLabel.DesiredSize.Height;
+            }
+            _grid.RowDefinitions[0].Height = new System.Windows.GridLength(newHeight);
+        }
+    }
+}

--- a/TAS.Client/UISettings.cs
+++ b/TAS.Client/UISettings.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TAS.Client
+{
+    static class UISettings
+    {
+        static readonly int fontDelta = 0;
+        static UISettings()
+        {
+            int.TryParse(System.Configuration.ConfigurationManager.AppSettings["UIFontDelta"], out fontDelta);
+            fontDelta = Math.Min(Math.Max(0, fontDelta), MaxFontDelta);
+        }
+        public static void Apply(System.Windows.Controls.TextBlock control, int maxFontDelta)
+        {
+            control.FontSize=GetFontSize(control.FontSize, maxFontDelta);
+        }
+        public static void ApplyToEventTime(System.Windows.Controls.TextBlock control) => Apply(control, EventTimeMaxFontDelta);
+        public static void Apply(System.Windows.Controls.TextBlock control) => Apply(control, MaxFontDelta);
+        public static double GetFontSize(double baseSize) => GetFontSize(baseSize, MaxFontDelta);
+        public static double GetFontSize(double baseSize, int maxFontDelta)
+        {
+            if (fontDelta > 0 && maxFontDelta > 0)
+            {
+                return baseSize + Math.Min(fontDelta, maxFontDelta);
+            }
+            return baseSize;
+        }
+        public const int EventTimeMaxFontDelta = 4;
+        public const int MaxFontDelta = 50;
+    }
+}

--- a/TAS.Client/Views/EngineView.xaml
+++ b/TAS.Client/Views/EngineView.xaml
@@ -283,7 +283,7 @@
                     </GroupBox>
                     <StackPanel Width="125">
                         <Label Content="{Resx _toolbar.TimeToAttention}" />
-                        <TextBlock Text="{Binding TimeToAttention, Converter={StaticResource TimeSpanToString}}" TextAlignment="Center" VerticalAlignment="Center" FontSize="26" Margin="5, 0">
+                        <TextBlock x:Name="lbAttentionTime" Text="{Binding TimeToAttention, Converter={StaticResource TimeSpanToString}}" TextAlignment="Center" VerticalAlignment="Center" FontSize="26" Margin="5, 0">
                             <TextBlock.Style>
                                 <Style TargetType="TextBlock">
                                     <Style.Triggers>
@@ -298,7 +298,7 @@
                             </TextBlock.Style>
                         </TextBlock>
                         <Label Content="{Resx _toolbar.NextWithRequestedStartTime}"/>
-                        <TextBlock FontSize="12" Text="{Binding NextWithRequestedStartTime.Offset, Converter={StaticResource TimeSpanToSignedString}}">
+                        <TextBlock x:Name="lbNextRequiredTime" FontSize="12" Text="{Binding NextWithRequestedStartTime.Offset, Converter={StaticResource TimeSpanToSignedString}}">
                             <TextBlock.ToolTip>
                                 <Run Text="{Binding NextWithRequestedStartTime.EventName}"/>
                             </TextBlock.ToolTip>
@@ -307,9 +307,9 @@
                     <ScrollViewer controls:WrapPanelFill.UseToFill="True" MinWidth="350" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Disabled" >
                         <StackPanel MaxWidth="{Binding RelativeSource={RelativeSource AncestorType=ScrollViewer}, Path=ActualWidth}">
                             <Label Content="{Resx _toolbar.NowPlaying}"  />
-                            <TextBlock Text="{Binding PlayingEventName}" />
+                            <TextBlock x:Name="lbNowPlayingName" Text="{Binding PlayingEventName}" />
                             <Label Content="{Resx _toolbar.Next}" />
-                            <TextBlock Text="{Binding NextToPlay}" HorizontalAlignment="Stretch" Width="Auto"/>
+                            <TextBlock x:Name="lbNextToPlayName" Text="{Binding NextToPlay}" HorizontalAlignment="Stretch" Width="Auto"/>
                         </StackPanel>
                     </ScrollViewer>
                 </controls:WrapPanelFill>

--- a/TAS.Client/Views/EngineView.xaml.cs
+++ b/TAS.Client/Views/EngineView.xaml.cs
@@ -19,6 +19,10 @@ namespace TAS.Client.Views
         public EngineView()
         {
             InitializeComponent();
+            UISettings.Apply(lbAttentionTime, 5);
+            UISettings.Apply(lbNextRequiredTime, 4);
+            UISettings.Apply(lbNowPlayingName);
+            UISettings.Apply(lbNextToPlayName);
         }
 
         private void SidePanelResizer_DragDelta(object sender, DragDeltaEventArgs e)

--- a/TAS.Client/Views/EventEditView.xaml
+++ b/TAS.Client/Views/EventEditView.xaml
@@ -17,6 +17,7 @@
              d:DataContext="{d:DesignInstance vm:EventEditViewmodel}"
              BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey }}"
              >
+    
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -88,6 +89,11 @@
                     <Setter Property="HorizontalAlignment" Value="Left"/>
                     <Setter Property="VerticalAlignment" Value="Center"/>
                     <Setter Property="Margin" Value="10, 3, 3, 0"/>
+                    <Style.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+                        </Trigger>
+                    </Style.Triggers>
                 </Style>
                 <Style TargetType="ComboBox">
                     <Setter Property="Margin" Value="1"/>
@@ -104,10 +110,10 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition />
                 </Grid.RowDefinitions>
-                <Label Grid.Row="0" Grid.Column="0" Content="{Resx _eventType}"/>
-                <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding EventType, Mode=OneWay}" IsEnabled="False" />
-                <Label Grid.Row="1" Grid.Column="0" Content="{Resx _name}"/>
-                <TextBox Grid.Row="1" Grid.Column="1" Name="EventName" Text="{Binding EventName, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" ToolTip="{Resx _eventName.ToolTip}">
+                <Label Grid.Row="0" Grid.Column="0" Content="{Resx _eventType}" FontWeight="Bold"/>
+                <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding EventType, Mode=OneWay}" IsEnabled="False" Margin="1,3,1,0" VerticalAlignment="Top"  FontWeight="Bold"/>
+                <Label Grid.Row="1" Grid.Column="0" Content="{Resx _name}" FontWeight="Bold"/>
+                <TextBox Grid.Row="1" Grid.Column="1" Name="EventName" Text="{Binding EventName, UpdateSourceTrigger=PropertyChanged, ValidatesOnDataErrors=True}" ToolTip="{Resx _eventName.ToolTip}" FontWeight="Bold">
                     <i:Interaction.Behaviors>
                         <behaviors:Focus IsFocused="{Binding IsEventNameFocused}" SelectAllOnFocus="True" />
                     </i:Interaction.Behaviors>
@@ -131,14 +137,14 @@
                         <RowDefinition Height="Auto"/>
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
-                    <CheckBox Grid.Row="0" Grid.Column="0" Content="{Resx _starting}" IsChecked="{Binding IsEnabled}" HorizontalContentAlignment="Right" VerticalAlignment="Center" ToolTip="{Resx _starting.ToolTip}" />
+                    <CheckBox Grid.Row="0" Grid.Column="0" Content="{Resx _starting}" IsChecked="{Binding IsEnabled}" HorizontalContentAlignment="Right" VerticalAlignment="Center" ToolTip="{Resx _starting.ToolTip}"  FontWeight="Bold"/>
                     <Grid Grid.Row="0" Grid.Column="1">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition />
                             <ColumnDefinition Width="Auto"/>
                         </Grid.ColumnDefinitions>
-                        <TextBox Grid.Row="0" Grid.Column="0" Text="{Binding StartType}" IsReadOnly="True" />
-                        <Button Grid.Row="0" Grid.Column="1" Height="20" Margin="5" Visibility="{Binding IsStartEvent, Converter={StaticResource BoolToVis}}" Command="{Binding CommandTriggerStartType}" Width="{Binding ActualHeight, RelativeSource={RelativeSource Self}}">
+                        <TextBox Grid.Row="0" Grid.Column="0" Text="{Binding StartType}" IsReadOnly="True"   FontWeight="Bold"/>
+                        <Button Grid.Row="0" Grid.Column="1" Height="20" Margin="5" Visibility="{Binding IsStartEvent, Converter={StaticResource BoolToVis}}" Command="{Binding CommandTriggerStartType}" Width="{Binding ActualHeight, RelativeSource={RelativeSource Self}}"  FontWeight="Bold">
                             <Image>
                                 <Image.Style>
                                     <Style TargetType="Image">
@@ -157,24 +163,26 @@
                             </Image>
                         </Button>
                     </Grid>
-                    <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding BoundEventName, Mode=OneWay}" IsReadOnly="True" Visibility="{Binding IsStartEvent, Converter={StaticResource InvertedBoolToVis}}"/>
+                    <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding BoundEventName, Mode=OneWay}" IsReadOnly="True" Visibility="{Binding IsStartEvent, Converter={StaticResource InvertedBoolToVis}}" FontWeight="Bold"/>
                     <Grid Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Visibility="{Binding IsAutoStartEvent, Converter={StaticResource BoolToVis}}">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" SharedSizeGroup="Labels" />
                             <ColumnDefinition Width="*"/>
                             <ColumnDefinition Width="*"/>
                         </Grid.ColumnDefinitions>
-                        <Label Content="Autostart"/>
-                        <CheckBox Grid.Column="1" Content="{Resx _autoStartForced}" ToolTip="{Resx _autoStartForced.ToolTip}" IsChecked="{Binding AutoStartForced}" Margin="1,3" Width="110"/>
-                        <CheckBox Grid.Column="2" Content="{Resx _autoStartEveryday}" IsChecked="{Binding AutoStartDaily}" Margin="1,3" Width="Auto" />
+                        <Label Content="Autostart" FontWeight="Bold"/>
+                        <CheckBox Grid.Column="1" Content="{Resx _autoStartForced}" ToolTip="{Resx _autoStartForced.ToolTip}" IsChecked="{Binding AutoStartForced}" Margin="1,3" Width="110" FontWeight="Bold"/>
+                        <CheckBox Grid.Column="2" Content="{Resx _autoStartEveryday}" IsChecked="{Binding AutoStartDaily}" Margin="1,3" Width="Auto"  FontWeight="Bold"/>
                     </Grid>
                     <Grid Grid.Row="3" Grid.Column="1" Visibility="{Binding IsMovieOrLiveOrRundown, Converter={StaticResource BoolToVis}}">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition/>
-                            <ColumnDefinition/>
+                            <ColumnDefinition Width="126*"/>
+                            <ColumnDefinition Width="14*"/>
+                            <ColumnDefinition Width="21*"/>
+                            <ColumnDefinition Width="90*"/>
                         </Grid.ColumnDefinitions>
-                        <CheckBox Grid.Column="0" Content="{Resx _hold}" IsChecked="{Binding IsHold}" IsEnabled="{Binding CanHold}" ToolTip="{Resx _hold.ToolTip}"  Margin="1,3" Width="110"/>
-                        <CheckBox Grid.Column="1" Content="{Resx _loop}" IsChecked="{Binding IsLoop}" IsEnabled="{Binding CanLoop}" Margin="1,3" />
+                        <CheckBox Grid.Column="0" Content="{Resx _hold}" IsChecked="{Binding IsHold}" IsEnabled="{Binding CanHold}" ToolTip="{Resx _hold.ToolTip}"  Margin="1,0,0,0" Width="110" FontWeight="Bold"/>
+                        <CheckBox Grid.Column="1" Content="{Resx _loop}" IsChecked="{Binding IsLoop}" IsEnabled="{Binding CanLoop}" Grid.ColumnSpan="3" Margin="10,3,0,0" VerticalAlignment="Top"  FontWeight="Bold"/>
                     </Grid>
 
                     <Grid Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2">
@@ -356,7 +364,7 @@
                                     <MultiBinding Converter="{StaticResource MultiBooleanOrNotNullToVisibilityConverter}">
                                         <Binding Path="IsLive"/>
                                         <Binding Path="RecordingInfoViewmodel"/>
-                                    </MultiBinding>                                    
+                                    </MultiBinding>
                                 </Grid.Visibility>
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="auto" />

--- a/TAS.Client/Views/EventEditView.xaml
+++ b/TAS.Client/Views/EventEditView.xaml
@@ -17,7 +17,6 @@
              d:DataContext="{d:DesignInstance vm:EventEditViewmodel}"
              BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey }}"
              >
-    
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>

--- a/TAS.Client/Views/EventPanelContainerView.xaml
+++ b/TAS.Client/Views/EventPanelContainerView.xaml
@@ -16,7 +16,7 @@
              d:DesignWidth="700"
              >
     <Border Style="{StaticResource EventPanelBaseStyle}">
-        <Grid Height="30">
+        <Grid  x:Name="mainGrid">
             <Grid.ContextMenu>
                 <ContextMenu>
                     <MenuItem Header="{Resx ResxName=TAS.Client.Views.EventPanelView, Key=_popupMenu.Paste}" Command="{Binding CommandPaste}" CommandParameter="Under"/>
@@ -30,13 +30,16 @@
                 <ColumnDefinition Width="40" />
                 <ColumnDefinition />
             </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="30" />
+            </Grid.RowDefinitions>
             <Image Margin="3" ToolTip="{Binding EventType}" Source="/TAS.Client.Common;component/Images/EventTypes/Container.png"/>
             <Image Source="/TAS.Client.Common;component/Images/Indicators/tick_circle.png" HorizontalAlignment="Left" VerticalAlignment="Top" Stretch="None" Visibility="{Binding IsMultiSelected, Converter={StaticResource BoolToVis}}" ToolTip="{Resx _isSelected}" />
             <TextBlock Grid.Column="1" Text="{Binding SubEventsCount, StringFormat={Resx _childrenCount, ResxName=TAS.Client.Views.EventPanelView}}" TextAlignment="Center" VerticalAlignment="Center"/>
             <Button Grid.Column="2" Margin="3" Visibility="{Binding IsSelected, Converter={StaticResource BoolToVis}}" ToolTip="{Resx _addSubRundown.ToolTip}" Command="{Binding CommandAddSubRundown}" Style="{StaticResource EventPanelCommandButton}">
                 <controls:AutoGreyableImage Source="/TAS.Client.Common;component/Images/EventActions/new-sub-rundown.png"/>
             </Button>
-            <TextBlock Grid.Column="3" Text="{Binding EventName}" FontSize="22" VerticalAlignment="Center" />
+            <TextBlock x:Name="lbContenerName" Grid.Column="3" Text="{Binding EventName}" FontSize="22" VerticalAlignment="Center" />
             <TextBlock Grid.Column="3" HorizontalAlignment="Right" VerticalAlignment="Top" Text="{Binding Id}" Visibility="{Binding ShowInDebugBuild}"/>
         </Grid>
     </Border>

--- a/TAS.Client/Views/EventPanelContainerView.xaml
+++ b/TAS.Client/Views/EventPanelContainerView.xaml
@@ -36,7 +36,7 @@
             <Image Margin="3" ToolTip="{Binding EventType}" Source="/TAS.Client.Common;component/Images/EventTypes/Container.png"/>
             <Image Source="/TAS.Client.Common;component/Images/Indicators/tick_circle.png" HorizontalAlignment="Left" VerticalAlignment="Top" Stretch="None" Visibility="{Binding IsMultiSelected, Converter={StaticResource BoolToVis}}" ToolTip="{Resx _isSelected}" />
             <TextBlock Grid.Column="1" Text="{Binding SubEventsCount, StringFormat={Resx _childrenCount, ResxName=TAS.Client.Views.EventPanelView}}" TextAlignment="Center" VerticalAlignment="Center"/>
-            <Button Grid.Column="2" Margin="3" Visibility="{Binding IsSelected, Converter={StaticResource BoolToVis}}" ToolTip="{Resx _addSubRundown.ToolTip}" Command="{Binding CommandAddSubRundown}" Style="{StaticResource EventPanelCommandButton}">
+            <Button Grid.Column="2" Margin="3" Visibility="{Binding IsSelected, Converter={StaticResource BoolToVis}}" ToolTip="{Resx _addSubRundown.ToolTip}" Command="{Binding CommandAddSubRundown}" Style="{StaticResource EventPanelCommandButton}" MaxWidth="27" MaxHeight="27">
                 <controls:AutoGreyableImage Source="/TAS.Client.Common;component/Images/EventActions/new-sub-rundown.png"/>
             </Button>
             <TextBlock x:Name="lbContenerName" Grid.Column="3" Text="{Binding EventName}" FontSize="22" VerticalAlignment="Center" />

--- a/TAS.Client/Views/EventPanelContainerView.xaml.cs
+++ b/TAS.Client/Views/EventPanelContainerView.xaml.cs
@@ -3,17 +3,34 @@ using System.Diagnostics;
 
 namespace TAS.Client.Views
 {
-    /// <summary>
-    /// Interaction logic for EventPanel.xaml
-    /// </summary>
-    /// 
+  /// <summary>
+  /// Interaction logic for EventPanel.xaml
+  /// </summary>
+  /// 
 
-    public partial class EventPanelContainerView : EventPanelView
+  public partial class EventPanelContainerView : EventPanelView
+  {
+    public EventPanelContainerView()
     {
-        public EventPanelContainerView()
-        {
-            InitializeComponent();
-        }
+      InitializeComponent();
+      ApplySettings();
     }
+    void ApplySettings()
+    {
+      var containerNameHeihgt = GetContainerNameHeight();
+      UISettings.Apply(lbContenerName);
+
+      var heightDiff = GetContainerNameHeight() - containerNameHeihgt - 5;
+      if (heightDiff > 0)
+      {
+        mainGrid.RowDefinitions[0].Height = new System.Windows.GridLength(mainGrid.RowDefinitions[0].Height.Value + heightDiff);
+      }
+    }
+    double GetContainerNameHeight()
+    {
+      lbContenerName.Measure(new System.Windows.Size(double.PositiveInfinity, double.PositiveInfinity));
+      return lbContenerName.DesiredSize.Height;
+    }
+  }
 
 }

--- a/TAS.Client/Views/EventPanelLiveView.xaml
+++ b/TAS.Client/Views/EventPanelLiveView.xaml
@@ -34,11 +34,12 @@
             <Border.Resources>
                 <Style TargetType="Button" BasedOn="{StaticResource EventPanelCommandButton}"/>
             </Border.Resources>
-            <Grid>
+            <Grid x:Name="mainGrid">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="33" />
                     <ColumnDefinition Width="31" />
                     <ColumnDefinition Width="80" />
+                    <ColumnDefinition Width="10" />
                     <ColumnDefinition />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
@@ -72,20 +73,20 @@
                             <Setter Property="VerticalAlignment" Value="Center"/>
                         </Style>
                     </StackPanel.Resources>
-                    <TextBlock Text="{Binding ScheduledTime}" ToolTip="{Resx _scheduledTime.ToolTip}" />
-                    <TextBlock Text="{Binding Offset, Converter={StaticResource TimeSpanToSignedString}}" Foreground="{Binding Offset, Converter={StaticResource TimeSpanToRedGreenBrushConverter}}" Visibility="{Binding Offset, Converter={StaticResource NullToVis}}" ToolTip="{Resx _offsetTime.ToolTip}"/>
-                    <TextBlock Text="{Binding Duration}" ToolTip="{Resx _duration.ToolTip}" />
-                    <TextBlock Text="{Binding EndTime}" Visibility="{Binding IsLoop, Converter={StaticResource InvertedBoolToVis}}" ToolTip="{Resx _endTime.ToolTip}"/>
+                    <TextBlock x:Name="lbScheduleTime" Text="{Binding ScheduledTime}" ToolTip="{Resx _scheduledTime.ToolTip}" />
+                    <TextBlock x:Name="lbOffset" Text="{Binding Offset, Converter={StaticResource TimeSpanToSignedString}}" Foreground="{Binding Offset, Converter={StaticResource TimeSpanToRedGreenBrushConverter}}" Visibility="{Binding Offset, Converter={StaticResource NullToVis}}" ToolTip="{Resx _offsetTime.ToolTip}"/>
+                    <TextBlock x:Name="lbDuration" Text="{Binding Duration}" ToolTip="{Resx _duration.ToolTip}" />
+                    <TextBlock x:Name="lbEndTime" Text="{Binding EndTime}" Visibility="{Binding IsLoop, Converter={StaticResource InvertedBoolToVis}}" ToolTip="{Resx _endTime.ToolTip}"/>
                     <Image Height="14" Source="/TAS.Client.Common;component/Images/Indicators/loop.png" Stretch="Uniform" Visibility="{Binding IsLoop, Converter={StaticResource BoolToVis}}" Style="{StaticResource EventPanelImage}"/>
                 </StackPanel>
-                <StackPanel Grid.Column="3" Grid.Row="0" VerticalAlignment="Center" >
-                    <TextBlock Text="{Binding EventName}" FontSize="20" Style="{StaticResource EventPanelTextBlock}" >
+                <StackPanel Grid.Column="4" Grid.Row="0" VerticalAlignment="Center" >
+                    <TextBlock x:Name="lbLiveEventName" Text="{Binding EventName}" FontSize="20" Style="{StaticResource EventPanelTextBlock}" >
                         <TextBlock.ToolTip>
                             <TextBlock Text="{Binding RootOwnerName, StringFormat={Resx _eventName.ToolTip, ResxName=TAS.Client.Views.EventPanelView}}" />
                         </TextBlock.ToolTip>
                     </TextBlock>
                 </StackPanel>
-                <StackPanel Grid.Column="3" Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" Visibility="{Binding IsSelected, Converter={StaticResource BoolToVis}}" >
+                <StackPanel Grid.Column="4" Grid.Row="2" Grid.ColumnSpan="2" Orientation="Horizontal" Visibility="{Binding IsSelected, Converter={StaticResource BoolToVis}}" >
                     <Button Command="{Binding CommandAddNextMovie}" ToolTip="{Resx _addNextMovie.ToolTip}" >
                         <controls:AutoGreyableImage Source="/TAS.Client.Common;component/Images/EventActions/new-movie.png"/>
                     </Button>
@@ -100,7 +101,7 @@
                     </Button>
                 </StackPanel>
                 <local:EventPanelCGElementsView Grid.Column="3" Grid.Row="1" Grid.ColumnSpan="2" HorizontalAlignment="Right"  Margin="5, 0" />
-                <TextBlock Grid.Column="4" Text="{Binding TimeLeft, Converter={StaticResource TimeSpanToString}}" FontSize="22" VerticalAlignment="Center" MinWidth="120" Margin="5, 0" Style="{StaticResource EventPanelTextBlock}" />
+                <TextBlock x:Name="lbTimeLeft" Grid.Column="4" Text="{Binding TimeLeft, Converter={StaticResource TimeSpanToString}}" FontSize="22" VerticalAlignment="Center" MinWidth="120" Margin="5, 0" Style="{StaticResource EventPanelTextBlock}" />
                 <TextBlock Grid.Column="4" HorizontalAlignment="Right" VerticalAlignment="Top" Text="{Binding Id}" Visibility="{Binding ShowInDebugBuild}"/>
             </Grid>
         </Border>

--- a/TAS.Client/Views/EventPanelLiveView.xaml
+++ b/TAS.Client/Views/EventPanelLiveView.xaml
@@ -48,7 +48,7 @@
                     <RowDefinition Height="26" />
                 </Grid.RowDefinitions>
                 <Border Grid.RowSpan="1" Background="{Binding MediaEmphasis, Converter={StaticResource MediaEmphasisToBrush}}"/>
-                <Border Grid.RowSpan="2" Grid.Column="2" Grid.ColumnSpan="3">
+                <Border Grid.RowSpan="2" Grid.Column="2" Grid.ColumnSpan="4">
                     <Border.Style>
                         <Style TargetType="Border">
                             <Style.Triggers>
@@ -100,9 +100,9 @@
                         <controls:AutoGreyableImage Source="/TAS.Client.Common;component/Images/EventActions/new-next-live.png"/>
                     </Button>
                 </StackPanel>
-                <local:EventPanelCGElementsView Grid.Column="3" Grid.Row="1" Grid.ColumnSpan="2" HorizontalAlignment="Right"  Margin="5, 0" />
-                <TextBlock x:Name="lbTimeLeft" Grid.Column="4" Text="{Binding TimeLeft, Converter={StaticResource TimeSpanToString}}" FontSize="22" VerticalAlignment="Center" MinWidth="120" Margin="5, 0" Style="{StaticResource EventPanelTextBlock}" />
-                <TextBlock Grid.Column="4" HorizontalAlignment="Right" VerticalAlignment="Top" Text="{Binding Id}" Visibility="{Binding ShowInDebugBuild}"/>
+                <local:EventPanelCGElementsView Grid.Column="4" Grid.Row="1" Grid.ColumnSpan="2" HorizontalAlignment="Right"  Margin="5, 0" />
+                <TextBlock x:Name="lbTimeLeft" Grid.Column="5" Text="{Binding TimeLeft, Converter={StaticResource TimeSpanToString}}" FontSize="22" VerticalAlignment="Center" MinWidth="120" Margin="5, 0" Style="{StaticResource EventPanelTextBlock}" />
+                <TextBlock Grid.Column="5" HorizontalAlignment="Right" VerticalAlignment="Top" Text="{Binding Id}" Visibility="{Binding ShowInDebugBuild}"/>
             </Grid>
         </Border>
     </StackPanel>

--- a/TAS.Client/Views/EventPanelLiveView.xaml.cs
+++ b/TAS.Client/Views/EventPanelLiveView.xaml.cs
@@ -1,18 +1,42 @@
 ﻿
 namespace TAS.Client.Views
 {
-    /// <summary>
-    /// Interaction logic for EventPanel.xaml
-    /// </summary>
-    /// 
+  /// <summary>
+  /// Interaction logic for EventPanel.xaml
+  /// </summary>
+  /// 
 
-    public partial class EventPanelLiveView : EventPanelView
+  public partial class EventPanelLiveView : EventPanelView
+  {
+    public EventPanelLiveView()
     {
-        public EventPanelLiveView()
-        {
-            InitializeComponent();
-        }
-      
+      InitializeComponent();
+      ApplySettings();
+      _resizer = new EventPanelResizer(mainGrid, lbOffset);
     }
+    readonly EventPanelResizer _resizer;
+    void ApplySettings()
+    {
+      var liveNameHeihgt = GetLiveNameHeight();
+      UISettings.Apply(lbLiveEventName);
+
+      UISettings.Apply(lbTimeLeft);
+      UISettings.ApplyToEventTime(lbScheduleTime);
+      UISettings.ApplyToEventTime(lbOffset);
+      UISettings.ApplyToEventTime(lbDuration);
+      UISettings.ApplyToEventTime(lbEndTime);
+
+      var heightDiff = GetLiveNameHeight() - liveNameHeihgt - 5;
+      if (heightDiff > 0)
+      {
+        mainGrid.RowDefinitions[0].Height = new System.Windows.GridLength(mainGrid.RowDefinitions[0].Height.Value + heightDiff);
+      }
+    }
+    double GetLiveNameHeight()
+    {
+      lbLiveEventName.Measure(new System.Windows.Size(double.PositiveInfinity, double.PositiveInfinity));
+      return lbLiveEventName.DesiredSize.Height;
+    }
+  }
 
 }

--- a/TAS.Client/Views/EventPanelMovieView.xaml
+++ b/TAS.Client/Views/EventPanelMovieView.xaml
@@ -34,11 +34,12 @@
             <Border.Resources>
                 <Style TargetType="Button" BasedOn="{StaticResource EventPanelCommandButton}"/>
             </Border.Resources>
-            <Grid>
+            <Grid x:Name="mainGrid">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="33" />
                     <ColumnDefinition Width="31" />
                     <ColumnDefinition Width="80" />
+                    <ColumnDefinition Width="10" />
                     <ColumnDefinition />
                 </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
@@ -130,29 +131,29 @@
                             <Setter Property="VerticalAlignment" Value="Center"/>
                         </Style>
                     </StackPanel.Resources>
-                    <TextBlock Text="{Binding ScheduledTime}" ToolTip="{Resx _scheduledTime.ToolTip}" />
-                    <TextBlock Text="{Binding Offset, Converter={StaticResource TimeSpanToSignedString}}" Foreground="{Binding Offset, Converter={StaticResource TimeSpanToRedGreenBrushConverter}}"  Visibility="{Binding Offset, Converter={StaticResource NullToVis}}" ToolTip="{Resx _offsetTime.ToolTip}"/>
-                    <TextBlock Text="{Binding Duration}" ToolTip="{Resx _duration.ToolTip}" />
-                    <TextBlock Text="{Binding EndTime}" Visibility="{Binding IsLoop, Converter={StaticResource InvertedBoolToVis}}" ToolTip="{Resx _endTime.ToolTip}"/>
+                    <TextBlock x:Name="lbScheduleTime" Text="{Binding ScheduledTime}" ToolTip="{Resx _scheduledTime.ToolTip}" />
+                    <TextBlock x:Name="lbOffset" Text="{Binding Offset, Converter={StaticResource TimeSpanToSignedString}}" Foreground="{Binding Offset, Converter={StaticResource TimeSpanToRedGreenBrushConverter}}"  Visibility="{Binding Offset, Converter={StaticResource NullToVis}}" ToolTip="{Resx _offsetTime.ToolTip}"/>
+                    <TextBlock x:Name="lbDuration" Text="{Binding Duration}" ToolTip="{Resx _duration.ToolTip}" />
+                    <TextBlock x:Name="lbEndTime" Text="{Binding EndTime}" Visibility="{Binding IsLoop, Converter={StaticResource InvertedBoolToVis}}" ToolTip="{Resx _endTime.ToolTip}"/>
                     <Image Height="14" Source="/TAS.Client.Common;component/Images/Indicators/loop.png" Stretch="Uniform" Visibility="{Binding IsLoop, Converter={StaticResource BoolToVis}}" Style="{StaticResource EventPanelImage}"/>
                 </StackPanel>
-                <Grid Grid.Column="3" Grid.Row="0" Grid.ColumnSpan="2" >
+                <Grid Grid.Column="4" Grid.Row="0" Grid.ColumnSpan="2" >
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <StackPanel>
-                        <TextBlock FontSize="19" Text="{Binding EventName}" Style="{StaticResource EventPanelTextBlock}">
+                        <TextBlock x:Name="lbEventName" FontSize="19" Text="{Binding EventName}" Style="{StaticResource EventPanelTextBlock}">
                             <TextBlock.ToolTip>
                                 <TextBlock Text="{Binding RootOwnerName, StringFormat={Resx _eventName.ToolTip, ResxName=TAS.Client.Views.EventPanelView}}" />
                             </TextBlock.ToolTip>
                         </TextBlock>
                         <TextBlock Style="{StaticResource MediaFileNameTextBlock}"/>
                     </StackPanel>
-                    <TextBlock Grid.Column="1" Text="{Binding TimeLeft, Converter={StaticResource TimeSpanToString}}" FontSize="22" VerticalAlignment="Center" Margin="5, 0" Style="{StaticResource EventPanelTextBlock}" />
+                    <TextBlock x:Name="lbTimeLeft" Grid.Column="1" Text="{Binding TimeLeft, Converter={StaticResource TimeSpanToString}}" FontSize="22" VerticalAlignment="Center" Margin="5, 0" Style="{StaticResource EventPanelTextBlock}" />
                     <TextBlock Grid.ColumnSpan="2" HorizontalAlignment="Right" VerticalAlignment="Top" Text="{Binding Id}" Visibility="{Binding ShowInDebugBuild}"/>
                 </Grid>
-                <StackPanel Grid.Column="3" Grid.Row="2" Orientation="Horizontal" Visibility="{Binding IsSelected,Converter={StaticResource BoolToVis}}">
+                <StackPanel Grid.Column="4" Grid.Row="2" Orientation="Horizontal" Visibility="{Binding IsSelected,Converter={StaticResource BoolToVis}}">
                     <Button Command="{Binding CommandAddNextMovie}" ToolTip="{Resx _addNextMovie.ToolTip}" >
                         <controls:AutoGreyableImage Source="/TAS.Client.Common;component/Images/EventActions/new-movie.png"/>
                     </Button>

--- a/TAS.Client/Views/EventPanelMovieView.xaml
+++ b/TAS.Client/Views/EventPanelMovieView.xaml
@@ -61,7 +61,7 @@
                     </Border.Style>
                     <Border Background="{Binding MediaEmphasis, Converter={StaticResource MediaEmphasisToBrush}}"/>
                 </Border>
-                <Border Grid.RowSpan="2" Grid.Column="2" Grid.ColumnSpan="3">
+                <Border Grid.RowSpan="2" Grid.Column="2" Grid.ColumnSpan="4">
                     <Border.Style>
                         <Style TargetType="Border">
                             <Style.Triggers>
@@ -167,7 +167,7 @@
                         <controls:AutoGreyableImage Source="/TAS.Client.Common;component/Images/EventActions/new-next-live.png"/>
                     </Button>
                 </StackPanel>
-                <local:EventPanelCGElementsView Grid.Column="3" Grid.Row="1" HorizontalAlignment="Right"  Margin="5, 0" />
+                <local:EventPanelCGElementsView Grid.Column="4" Grid.Row="1" HorizontalAlignment="Right"  Margin="5, 0" />
             </Grid>
         </Border>
     </StackPanel>

--- a/TAS.Client/Views/EventPanelMovieView.xaml.cs
+++ b/TAS.Client/Views/EventPanelMovieView.xaml.cs
@@ -11,8 +11,40 @@ namespace TAS.Client.Views
         public EventPanelMovieView()
         {
             InitializeComponent();
+            Loaded += EventPanelMovieView_Loaded;
+
         }
-      
+
+        private void EventPanelMovieView_Loaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            ApplySettings();
+            Loaded -= EventPanelMovieView_Loaded;
+        }
+
+        EventPanelResizer _resizer;
+        void ApplySettings()
+        {
+            var nameHeihgt = GetNameHeight();
+            UISettings.Apply(lbEventName);
+
+            UISettings.Apply(lbTimeLeft);
+            UISettings.ApplyToEventTime(lbScheduleTime);
+            UISettings.ApplyToEventTime(lbOffset);
+            UISettings.ApplyToEventTime(lbDuration);
+            UISettings.ApplyToEventTime(lbEndTime);
+            
+            var heightDiff = GetNameHeight() - nameHeihgt;
+            if (heightDiff > 0)
+            {
+                mainGrid.RowDefinitions[0].Height = new System.Windows.GridLength(mainGrid.RowDefinitions[0].Height.Value + heightDiff);
+            }
+            _resizer = new EventPanelResizer(mainGrid, lbOffset);
+        }
+        double GetNameHeight()
+        {
+            lbEventName.Measure(new System.Windows.Size(double.PositiveInfinity, double.PositiveInfinity));
+            return lbEventName.DesiredSize.Height;
+        }
     }
 
 }

--- a/TAS.Client/Views/EventPanelRundownView.xaml
+++ b/TAS.Client/Views/EventPanelRundownView.xaml
@@ -32,11 +32,12 @@
             <Border.Resources>
                 <Style TargetType="Button" BasedOn="{StaticResource EventPanelCommandButton}"/>
             </Border.Resources>
-            <Grid>
+            <Grid x:Name="mainGrid">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="33" />
                     <ColumnDefinition Width="31" />
                     <ColumnDefinition Width="80" />
+                    <ColumnDefinition Width="10" />
                     <ColumnDefinition />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
@@ -70,18 +71,18 @@
                             <Setter Property="VerticalAlignment" Value="Center"/>
                         </Style>
                     </StackPanel.Resources>
-                    <TextBlock Text="{Binding ScheduledTime}" ToolTip="{Resx _scheduledTime.ToolTip}" />
-                    <TextBlock Text="{Binding Offset, Converter={StaticResource TimeSpanToSignedString}}" Foreground="{Binding Offset, Converter={StaticResource TimeSpanToRedGreenBrushConverter}}" Visibility="{Binding Offset, Converter={StaticResource NullToVis}}" ToolTip="{Resx _offsetTime.ToolTip}"/>
-                    <TextBlock Text="{Binding Duration}" ToolTip="{Resx _duration.ToolTip}"/>
-                    <TextBlock Text="{Binding EndTime}" Visibility="{Binding IsLoop, Converter={StaticResource InvertedBoolToVis}}" ToolTip="{Resx _endTime.ToolTip}" />
+                    <TextBlock x:Name="lbScheduleTime" Text="{Binding ScheduledTime}" ToolTip="{Resx _scheduledTime.ToolTip}" />
+                    <TextBlock x:Name="lbOffset" Text="{Binding Offset, Converter={StaticResource TimeSpanToSignedString}}" Foreground="{Binding Offset, Converter={StaticResource TimeSpanToRedGreenBrushConverter}}" Visibility="{Binding Offset, Converter={StaticResource NullToVis}}" ToolTip="{Resx _offsetTime.ToolTip}"/>
+                    <TextBlock x:Name="lbDuration" Text="{Binding Duration}" ToolTip="{Resx _duration.ToolTip}"/>
+                    <TextBlock x:Name="lbEndTime" Text="{Binding EndTime}" Visibility="{Binding IsLoop, Converter={StaticResource InvertedBoolToVis}}" ToolTip="{Resx _endTime.ToolTip}" />
                     <Image Height="14" Source="/TAS.Client.Common;component/Images/Indicators/loop.png" Stretch="Uniform" Visibility="{Binding IsLoop, Converter={StaticResource BoolToVis}}" Style="{StaticResource EventPanelImage}"/>
                 </StackPanel>
-                <TextBlock Grid.Column="3" Grid.Row="0" Text="{Binding EventName}" FontSize="22" VerticalAlignment="Center" Margin="5, 0" Style="{StaticResource EventPanelTextBlock}">
+                <TextBlock x:Name="lbRundownName" Grid.Column="4" Grid.Row="0" Text="{Binding EventName}" FontSize="22" VerticalAlignment="Center" Margin="5, 0" Style="{StaticResource EventPanelTextBlock}">
                     <TextBlock.ToolTip>
                         <TextBlock Text="{Binding RootOwnerName, StringFormat={Resx _eventName.ToolTip, ResxName=TAS.Client.Views.EventPanelView}}" />
                     </TextBlock.ToolTip>
                     </TextBlock>
-                <StackPanel Orientation="Horizontal" Grid.Column="3" Grid.Row="1" Grid.ColumnSpan="2" Visibility="{Binding IsSelected, Converter={StaticResource BoolToVis}}">
+                <StackPanel Orientation="Horizontal" Grid.Column="4" Grid.Row="1" Grid.ColumnSpan="2" Visibility="{Binding IsSelected, Converter={StaticResource BoolToVis}}">
                     <Button Command="{Binding CommandAddSubMovie}" ToolTip="{Resx _addSubMovie.ToolTip}" >
                         <controls:AutoGreyableImage Source="/TAS.Client.Common;component/Images/EventActions/new-sub-movie.png"/>
                     </Button>
@@ -102,8 +103,8 @@
                         <controls:AutoGreyableImage Source="/TAS.Client.Common;component/Images/EventActions/new-next-live.png"/>
                     </Button>
                 </StackPanel>
-                <TextBlock Grid.Column="4" Text="{Binding TimeLeft, Converter={StaticResource TimeSpanToString}}" FontSize="22" VerticalAlignment="Center" MinWidth="120" Margin="5, 0" Style="{StaticResource EventPanelTextBlock}" />
-                <TextBlock Grid.Column="4" HorizontalAlignment="Right" VerticalAlignment="Top" Text="{Binding Id}" Visibility="{Binding ShowInDebugBuild}"/>
+                <TextBlock x:Name="lbTimeLeft" Grid.Column="5" Text="{Binding TimeLeft, Converter={StaticResource TimeSpanToString}}" FontSize="22" VerticalAlignment="Center" MinWidth="120" Margin="5, 0" Style="{StaticResource EventPanelTextBlock}" />
+                <TextBlock Grid.Column="5" HorizontalAlignment="Right" VerticalAlignment="Top" Text="{Binding Id}" Visibility="{Binding ShowInDebugBuild}"/>
             </Grid>
         </Border>
     </StackPanel>

--- a/TAS.Client/Views/EventPanelRundownView.xaml
+++ b/TAS.Client/Views/EventPanelRundownView.xaml
@@ -45,7 +45,7 @@
                     <RowDefinition Height="35" />
                     <RowDefinition Height="26" />
                 </Grid.RowDefinitions>
-                <Border Grid.RowSpan="2" Grid.Column="2" Grid.ColumnSpan="3">
+                <Border Grid.RowSpan="2" Grid.Column="2" Grid.ColumnSpan="4">
                     <Border.Style>
                         <Style TargetType="Border">
                             <Style.Triggers>

--- a/TAS.Client/Views/EventPanelRundownView.xaml.cs
+++ b/TAS.Client/Views/EventPanelRundownView.xaml.cs
@@ -10,8 +10,32 @@ namespace TAS.Client.Views
         public EventPanelRundownView()
         {
             InitializeComponent();
+            ApplySettings();
+            _resizer = new EventPanelResizer(mainGrid, lbOffset);
         }
-      
+        readonly EventPanelResizer _resizer;
+        void ApplySettings()
+        {
+            var rundownNameHeihgt = GetRundownNameHeight();
+            UISettings.Apply(lbRundownName);
+
+            UISettings.Apply(lbTimeLeft);
+            UISettings.ApplyToEventTime(lbScheduleTime);
+            UISettings.ApplyToEventTime(lbOffset);
+            UISettings.ApplyToEventTime(lbDuration);
+            UISettings.ApplyToEventTime(lbEndTime);
+
+            var heightDiff = GetRundownNameHeight() - rundownNameHeihgt - 5;
+            if (heightDiff > 0)
+            {
+                mainGrid.RowDefinitions[0].Height = new System.Windows.GridLength(mainGrid.RowDefinitions[0].Height.Value + heightDiff);
+            }
+        }
+        double GetRundownNameHeight()
+        {
+            lbRundownName.Measure(new System.Windows.Size(double.PositiveInfinity, double.PositiveInfinity));
+            return lbRundownName.DesiredSize.Height;
+        }
     }
 
 }

--- a/TAS.Client/Views/MediaManagerView.pl.resx
+++ b/TAS.Client/Views/MediaManagerView.pl.resx
@@ -264,4 +264,7 @@
   <data name="_toolbar.Ingest.ToolTip" xml:space="preserve">
     <value>Pobierz do emisji</value>
   </data>
+   <data name="_menu.Tools.ShowFileNames" xml:space="preserve">
+    <value>Pokazuj nazwy plików</value>
+  </data>
 </root>

--- a/TAS.Client/Views/MediaManagerView.resx
+++ b/TAS.Client/Views/MediaManagerView.resx
@@ -264,4 +264,7 @@
   <data name="_toolbar.Ingest.ToolTip" xml:space="preserve">
     <value>Ingest to playout</value>
   </data>
+  <data name="_menu.Tools.ShowFileNames" xml:space="preserve">
+    <value>Show file names</value>
+  </data>
 </root>

--- a/TAS.Client/Views/MediaManagerView.xaml
+++ b/TAS.Client/Views/MediaManagerView.xaml
@@ -135,6 +135,8 @@
                 <MenuItem Header="{Resx _menu.Tools}">
                     <MenuItem Header="{Resx _menu.Tools.SynchronizeSecToPri}" Command="{Binding CommandSyncPriToSec}"/>
                     <MenuItem Header="{Resx _menu.Tools.VerifyAllMedia}" Command="{Binding CommandVerifyAllMedia}"/>
+                    <Separator />
+                    <MenuItem Name="cbShowFileNames" Header="{Resx _menu.Tools.ShowFileNames}" IsCheckable="True" IsChecked="False"/>
                 </MenuItem>
             </Menu>
             <TabControl Grid.Row="0">
@@ -467,16 +469,26 @@
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>
-                                <DataGridTextColumn x:Name="ingestDateColumn" Header="{Resx ResxName=TAS.Client.Views.MediaManagerView, Key=_grid.Header.IngestDate}" Width="120" Binding="{Binding LastUpdated, StringFormat=g, Mode=OneWay, Converter={StaticResource DateTimeToStringConverter}}" />
-                                <DataGridTemplateColumn x:Name="durationColumn" Header="{Resx ResxName=TAS.Client.Views.MediaManagerView, Key=_grid.Header.DurationPlay}"  Width="90" SortMemberPath="DurationPlay">
+                                <DataGridTextColumn x:Name="ingestDateColumn" Header="{Resx ResxName=TAS.Client.Views.MediaManagerView, Key=_grid.Header.IngestDate}" Width="SizeToCells" Binding="{Binding LastUpdated, StringFormat=g, Mode=OneWay, Converter={StaticResource DateTimeToStringConverter}}" CanUserResize="False">
+                                    <DataGridTextColumn.ElementStyle>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="Margin" Value="6,0,6,0"/>
+                                        </Style>
+                                    </DataGridTextColumn.ElementStyle>
+                                </DataGridTextColumn>
+                                <DataGridTemplateColumn x:Name="durationColumn" Header="{Resx ResxName=TAS.Client.Views.MediaManagerView, Key=_grid.Header.DurationPlay}"  Width="SizeToCells" SortMemberPath="DurationPlay" CanUserResize="False">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
-                                            <controls:TimecodeTextBlock Timecode="{Binding DurationPlay}" VideoFormat="{Binding VideoFormat}"/>
+                                            <controls:TimecodeTextBlock Timecode="{Binding DurationPlay}" VideoFormat="{Binding VideoFormat}" Margin="6,0,6,0"/>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
+                                    
                                 </DataGridTemplateColumn>
-                                <DataGridTextColumn Header="{Resx ResxName=TAS.Client.Views.MediaManagerView, Key=_grid.Header.Folder}" Visibility="{Binding Data.IsDisplayFolder,  Source={StaticResource proxy}, Converter={StaticResource BoolToVis}}" Width="*" Binding="{Binding Folder, Mode=OneWay}" />
-                                <DataGridTextColumn Header="{Resx ResxName=TAS.Client.Views.MediaManagerView, Key=_grid.Header.FileName}" Width="*" Binding="{Binding FileName, Mode=OneWay}" />
+                                <DataGridTextColumn Header="{Resx ResxName=TAS.Client.Views.MediaManagerView, Key=_grid.Header.Folder}" Visibility="{Binding Data.IsDisplayFolder,  Source={StaticResource proxy}, Converter={StaticResource BoolToVis}}" Width="*" Binding="{Binding Folder, Mode=OneWay}"/>
+                                
+
+                                <DataGridTextColumn x:Name="clFileName" Header="{Resx ResxName=TAS.Client.Views.MediaManagerView, Key=_grid.Header.FileName}" Width="*" Binding="{Binding FileName, Mode=OneWay}" />
+
                             </DataGrid.Columns>
                             <DataGrid.RowDetailsTemplate>
                                 <DataTemplate>

--- a/TAS.Client/Views/MediaManagerView.xaml.cs
+++ b/TAS.Client/Views/MediaManagerView.xaml.cs
@@ -25,8 +25,19 @@ namespace TAS.Client.Views
         public MediaManagerView()
         {
             InitializeComponent();
+            SetFileNamesVisibility();
+            cbShowFileNames.Checked += (s, e) => SetFileNamesVisibility();
+            cbShowFileNames.Unchecked += (s, e) => SetFileNamesVisibility();
+            MediaListGrid.RowStyle = new Style(typeof(DataGridRow))
+            {
+                Setters = { new Setter(Control.FontSizeProperty, UISettings.GetFontSize(MediaListGrid.FontSize)) }
+            };
         }
 
+        void SetFileNamesVisibility()
+        {
+            clFileName.Visibility = cbShowFileNames.IsChecked ? Visibility.Visible : Visibility.Hidden;
+        }
 
         private void UserControl_KeyUp(object sender, KeyEventArgs e)
         {

--- a/TVPlay/MainWindow.xaml.cs
+++ b/TVPlay/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Input;
 using System.Diagnostics;
 using resources = TAS.Client.Common.Properties.Resources;
+using TAS.Server;
 
 namespace TAS.Client
 {


### PR DESCRIPTION
Doszła statyczna klasa UISettings, która udostępnia metody modyfikacji rozmiaru czcionek w zależności od ustawienia w app.config
Zmodyfikowano niektóre .xaml by wprowadzić nazwy elementów, oraz odpowiednie .xaml.cs tak by wykorzystać UISettings przy tworzeniu/ładowaniu odpowiednich widoków
Dodatkowo dodałem klasę EventPanelResizer, która kontroluje rozmiar wiersza zdarzenia w zależności od widoczności wartości "Offset"